### PR TITLE
Migrate cdn from RawGit to jsDelivr

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
           </ul>
           <div class="cde">
             <div class="cde-com">&lt;!-- in your header --&gt;</div>
-            &lt;link rel="stylesheet" href="https://cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css"&gt;<br />
+            &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/konpa/devicon@master/devicon.min.css"&gt;<br />
             <br />
             <div class="cde-com">&lt;!-- in your body --&gt;</div>
             &lt;i class="devicon-{{selectedIcon.name}}-{{selectedFontIcon}}<span ng-if="colored"> colored</span>"&gt;&lt;/i&gt;<br />


### PR DESCRIPTION
As @samfuller01 pointed out in https://github.com/konpa/devicon/issues/163, [RawGit](https://rawgit.com/) has officially ended support in october 2019. [jsDelivr](https://www.jsdelivr.com/) looks like an easy to maintain replacement.
