### PR TITLE
Upgrade gulp and build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,27 @@ Please have a look at the [CONTRIBUTING.md](https://github.com/konpa/devicon/blo
 Under [MIT Licence](https://github.com/konpa/devicon/blob/master/LICENSE)
 
 <sub>All product names, logos, and brands are property of their respective owners. All company, product and service names used in this website are for identification purposes only. Use of these names, logos, and brands does not imply endorsement.</sub>
+
+## Go build yourself
+### Prerequisites
+Install gulp (and gulp plugins)
+```bash
+npm install
+```
+### Build the font and export stylesheet
+Open [icomoon app](https://icomoon.io/app/#/select) and import [icomoon.json](icomoon.json). Choose _yes_ when beeing asked
+if you like to restore the settings stored in the configuration file.
+
+The next step is to click on **Generate font** and download the resulting archive. Extract it
+contents and you will find a [fonts](./fonts) directory next to a `style.css`. Replace the content of the `fonts` folder,
+merge the `style.css` with [devicon.css](./devicon.css) and follow the next step to build the final stylesheet.
+
+**Note** the merge is required, because some icons are defined as alias, this should be replaced
+with a more elegant solution to support automated build processing.
+
+### Build and minify stylesheet
+Run the following commands to build the resulting file `devicon.min.css`
+```bash
+gulp concat-css
+gulp minify-css
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,14 +4,14 @@ var concatCss = require('gulp-concat-css');
 var plumber = require('gulp-plumber');
 
 gulp.task('concat-css', function () {
-  gulp.src(['./devicon.css', './devicon-colors.css'])
+  return gulp.src(['./devicon.css', './devicon-colors.css'])
   .pipe(plumber())
   .pipe(concatCss('./devicon.min.css'))
   .pipe(gulp.dest('./'));
 });
 
 gulp.task('minify-css', function() {
-  gulp.src('./devicon.min.css')
+  return gulp.src('./devicon.min.css')
   .pipe(plumber())
   .pipe(minifyCSS())
   .pipe(gulp.dest('./'))

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "http://konpa.github.io/devicon/",
   "devDependencies": {
-    "gulp": "^3.8.10",
+    "gulp": "^4.0.0",
     "gulp-concat-css": "^2.0.0",
     "gulp-minify-css": "^0.4.3",
     "gulp-plumber": "^0.6.6"


### PR DESCRIPTION
- upgrade gulp v3 to v4 and migrate gulp tasks; 
- documentation about the build process