### PR TITLE
fix devicon.json redux font property; remove grails original font

### DIFF
--- a/devicon-colors.css
+++ b/devicon-colors.css
@@ -569,7 +569,6 @@
 .devicon-groovy-plain.colored {
 	color: #619cbc;
 }
-.devicon-grails-original.colored,
 .devicon-grails-plain.colored {
 	color: #feb672;
 }

--- a/devicon.json
+++ b/devicon.json
@@ -763,7 +763,8 @@
     "name": "redux",
     "tags": ["framework"],
     "versions": {
-      "svg": ["original"]
+      "svg": ["original"],
+      "font": []
     }
   },
   {

--- a/devicon.json
+++ b/devicon.json
@@ -412,7 +412,7 @@
     "tags": ["framework"],
     "versions": {
       "svg": ["original", "plain"],
-      "font": ["original", "plain"]
+      "font": ["plain"]
     }
   },
   {


### PR DESCRIPTION
The missing font property on redux leads to an js error in the gh-page which results into a incomplete listing of icons. Each icon below "redux" in `devicons.json` wasn't displayed on the gh-page.

![image](https://user-images.githubusercontent.com/8781699/86510922-8a689100-bdf4-11ea-8044-a0af4796fb53.png)
