### PR TITLE
Add optimize_icons workflow triggered on push

### DIFF
--- a/.github/workflows/optimize_icons.yml
+++ b/.github/workflows/optimize_icons.yml
@@ -1,0 +1,23 @@
+name: Optimize icons
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  optimize:
+    runs-on: ubuntu-latest
+    name: Optimize icons with SVGO
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ericcornelissen/svgo-action@v3
+        id: svgo
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          svgo-config: ./.github/scripts/svgo.config.js
+          svgo-version: 3
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "SVG Optimization: ${{ steps.svgo.outputs.OPTIMIZED_COUNT }}/${{ steps.svgo.outputs.SVG_COUNT }} SVGs got optimized."


### PR DESCRIPTION
## Double-check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes as appropriate -->

This PR closes #1715

## Notes

This PR replaces the now closed #1718.

In the previous version, we were trying to make it run on the PR itself, but that doesn't seem to be possible, given the following:

- The `ericcornelissen/svgo-action@v3` action [does not support](https://github.com/ericcornelissen/svgo-action/blob/main/docs/events.md) a `workflow_run` trigger
- The GITHUB_TOKEN [does not have permission to write](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) when invoked by PRs from public forks

This version simply runs the optimizer after the PR merge (on the corresponding push). I have tested this with a second fork of the repository, and it seems to work as expected. According to the [documentation](https://github.com/ericcornelissen/svgo-action/blob/main/docs/events.md#on-push)) when SVGO is invoked on `push`:

> In the push context the SVGO Action will optimize all SVGs that have been added or modified in the commit(s) being pushed. Any SVGs that are in the repository but have not been modified in the commit(s) will not be optimized.

Doing this on the push has the disadvantage of not allowing us to review the optimized versions, but it will ensure all icons in `develop` are optimized.