### PR TITLE
ci(dependencies): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+      devicon-actions:
+        applies-to: version-updates
+        patterns:
+          - "devicons/*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "10:00"
+    target-branch: "develop"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes if appropriate -->
This PR adds a dependabot configuration to automatically update dependencies. It will automatically create PRs for outdated dependencies of the following types.

- github actions
- npm (all dev dependencies will be grouped into a single PR)
- python/pip (this normally works for `requirements*.txt` files even in subfolders, but I don't know if will work in the `.github` directory)

**This PR closes NONE**
<!-- List issues that this PR would close above. Ex: This PR closes #1, #2, #3. -->
<!-- If your pull request does not fix any issue, it's best to make an issue OR remove this section, depending on your changes. -->

## Notes
<!-- List anything note-worthy here (potential issues, this needs to be merged to `master` before working, etc.). -->

This will not start working until the file exists on the default branch. Additionally, dependabot will only run the config that exists on the default branch. This is one reason I would suggest making the default branch `develop`, although there are plenty of other reasons which mostly involve improving the developer experience.

Personally, I set my dependabot config to run daily, but that may be too overwhelming/annoying for this repo, so I changed it to weekly.

For more dependabot config options, here is the official documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file