### PR TITLE
ci: add `semantic.yml`

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,24 @@
+---
+# This is the configuration file for https://github.com/Ezard/semantic-prs
+
+enabled: true
+titleOnly: true  # We only use the PR title as we squash and merge
+commitsOnly: false
+titleAndCommits: false
+anyCommit: false
+allowMergeCommits: false
+allowRevertCommits: true
+targetUrl: 'https://github.com/devicons/devicon/blob/master/.github/semantic.yml'
+types:
+  # default conventional commit types (for non icon PRs)
+  - 'chore'
+  - 'ci'
+  - 'docs'
+  - 'feat'
+  - 'fix'
+  - 'refactor'
+  - 'style'
+  - 'test'
+  # custom devicon types (for icon PRs)
+  - 'new icon'
+  - 'update icon'


### PR DESCRIPTION
## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes if appropriate -->
This PR adds a `semantic.yml` to be used with https://github.com/Ezard/semantic-prs

> [!NOTE]
> This app needs to be installed to the org and given permission to access this repository.

This can hopefully avoid the issue of contributors prefixing PR titles with spaces or other things that may be difficult to catch with a manual review.

## Notes
<!-- List anything note-worthy here (potential issues, this needs to be merged to `master` before working, etc.). -->
I use this app in https://github.com/LizardByte across every repo, although with default "types". In this case I have kept the default types as well as added the two custom ones that I know of for devicons.

This configuration will only check the PR title, and not the individual commit messages. This is the easiest approach as maintainers (or at least admins) can edit the PR title without asking the user to do it.

I didn't find any style for removing icons, let me know if there is one.

- https://github.com/devicons/devicon/blob/ca28c779441053191ff11710fe24a9e6c23690d6/.github/scripts/build_assets/util.py#L63