### PR TITLE
new icon: seaborn (original, original-wordmark, plain, plain-wordmark, line)

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -1,4 +1,4 @@
-[
+﻿[
     {
         "name": "aarch64",
         "altnames": [
@@ -11466,6 +11466,37 @@
             }
         ]
     },
+    },
+    {
+        "name": "seaborn",
+        "altnames": [
+            "sns"
+        ],
+        "tags": [
+            "python",
+            "data-visualization",
+            "statistics",
+            "matplotlib",
+            "library",
+            "data-science",
+            "analytics"
+        ],
+        "versions": {
+            "svg": [
+                "original",
+                "original-wordmark",
+                "plain",
+                "plain-wordmark",
+                "line"
+            ],
+            "font": [
+                "plain",
+                "plain-wordmark",
+                "line"
+            ]
+        },
+        "color": "#4472C4",
+        "aliases": []
     {
         "name": "scala",
         "altnames": [

--- a/icons/seaborn/seaborn-line.svg
+++ b/icons/seaborn/seaborn-line.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Seaborn Line Logo - Minimalist outline version -->
+  <circle cx="64" cy="64" r="58" fill="none" stroke="#4472C4" stroke-width="2"/>
+  
+  <!-- Simplified wave patterns as lines -->
+  <path d="M25 64 Q35 48, 45 64 T65 64" fill="none" stroke="#4472C4" stroke-width="2"/>
+  <path d="M25 72 Q35 56, 45 72 T65 72" fill="none" stroke="#4472C4" stroke-width="2"/>
+  <path d="M25 56 Q35 40, 45 56 T65 56" fill="none" stroke="#4472C4" stroke-width="2"/>
+  
+  <!-- Data points as small circles -->
+  <circle cx="30" cy="64" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="45" cy="48" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="60" cy="64" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  
+  <circle cx="30" cy="72" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="45" cy="56" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="60" cy="72" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  
+  <circle cx="30" cy="56" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="45" cy="40" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  <circle cx="60" cy="56" r="2" fill="none" stroke="#4472C4" stroke-width="1.5"/>
+  
+  <!-- Bar chart as outlines -->
+  <rect x="75" y="42" width="6" height="20" fill="none" stroke="#4472C4" stroke-width="2"/>
+  <rect x="83" y="52" width="6" height="10" fill="none" stroke="#4472C4" stroke-width="2"/>
+  <rect x="91" y="32" width="6" height="30" fill="none" stroke="#4472C4" stroke-width="2"/>
+</svg>

--- a/icons/seaborn/seaborn-original-wordmark.svg
+++ b/icons/seaborn/seaborn-original-wordmark.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Seaborn Original Wordmark - Icon with text -->
+  <circle cx="64" cy="48" r="35" fill="#ffffff" stroke="#4A4A4A" stroke-width="1.5"/>
+  
+  <!-- Wave patterns representing data visualization -->
+  <path d="M35 48 Q42 35, 49 48 T63 48" fill="none" stroke="#1f77b4" stroke-width="2"/>
+  <path d="M35 54 Q42 41, 49 54 T63 54" fill="none" stroke="#ff7f0e" stroke-width="2"/>
+  <path d="M35 42 Q42 29, 49 42 T63 42" fill="none" stroke="#2ca02c" stroke-width="2"/>
+  
+  <!-- Data points -->
+  <circle cx="38" cy="48" r="2.5" fill="#1f77b4"/>
+  <circle cx="49" cy="35" r="2.5" fill="#1f77b4"/>
+  <circle cx="60" cy="48" r="2.5" fill="#1f77b4"/>
+  
+  <circle cx="38" cy="54" r="2.5" fill="#ff7f0e"/>
+  <circle cx="49" cy="41" r="2.5" fill="#ff7f0e"/>
+  <circle cx="60" cy="54" r="2.5" fill="#ff7f0e"/>
+  
+  <circle cx="38" cy="42" r="2.5" fill="#2ca02c"/>
+  <circle cx="49" cy="29" r="2.5" fill="#2ca02c"/>
+  <circle cx="60" cy="42" r="2.5" fill="#2ca02c"/>
+  
+  <!-- Bar chart representation -->
+  <rect x="70" y="35" width="5" height="13" fill="#d62728"/>
+  <rect x="76" y="40" width="5" height="8" fill="#9467bd"/>
+  <rect x="82" y="30" width="5" height="18" fill="#8c564b"/>
+  
+  <!-- Seaborn text -->
+  <text x="64" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#4A4A4A">seaborn</text>
+</svg>

--- a/icons/seaborn/seaborn-original.svg
+++ b/icons/seaborn/seaborn-original.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Seaborn Original Logo - Based on the official cubehelix color scheme -->
+  <circle cx="64" cy="64" r="60" fill="#ffffff" stroke="#4A4A4A" stroke-width="2"/>
+  
+  <!-- Wave patterns representing data visualization -->
+  <path d="M20 64 Q32 44, 44 64 T68 64" fill="none" stroke="#1f77b4" stroke-width="3"/>
+  <path d="M20 74 Q32 54, 44 74 T68 74" fill="none" stroke="#ff7f0e" stroke-width="3"/>
+  <path d="M20 54 Q32 34, 44 54 T68 54" fill="none" stroke="#2ca02c" stroke-width="3"/>
+  
+  <!-- Data points -->
+  <circle cx="28" cy="64" r="4" fill="#1f77b4"/>
+  <circle cx="44" cy="44" r="4" fill="#1f77b4"/>
+  <circle cx="60" cy="64" r="4" fill="#1f77b4"/>
+  
+  <circle cx="28" cy="74" r="4" fill="#ff7f0e"/>
+  <circle cx="44" cy="54" r="4" fill="#ff7f0e"/>
+  <circle cx="60" cy="74" r="4" fill="#ff7f0e"/>
+  
+  <circle cx="28" cy="54" r="4" fill="#2ca02c"/>
+  <circle cx="44" cy="34" r="4" fill="#2ca02c"/>
+  <circle cx="60" cy="54" r="4" fill="#2ca02c"/>
+  
+  <!-- Bar chart representation -->
+  <rect x="76" y="40" width="8" height="24" fill="#d62728"/>
+  <rect x="86" y="50" width="8" height="14" fill="#9467bd"/>
+  <rect x="96" y="30" width="8" height="34" fill="#8c564b"/>
+  
+  <!-- Seaborn text -->
+  <text x="64" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#4A4A4A">seaborn</text>
+</svg>

--- a/icons/seaborn/seaborn-plain-wordmark.svg
+++ b/icons/seaborn/seaborn-plain-wordmark.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Seaborn Plain Wordmark - Single color with text -->
+  <circle cx="64" cy="48" r="35" fill="none" stroke="#4472C4" stroke-width="2"/>
+  
+  <!-- Simplified wave patterns -->
+  <path d="M35 48 Q42 35, 49 48 T63 48" fill="none" stroke="#4472C4" stroke-width="2.5"/>
+  <path d="M35 54 Q42 41, 49 54 T63 54" fill="none" stroke="#4472C4" stroke-width="2.5"/>
+  <path d="M35 42 Q42 29, 49 42 T63 42" fill="none" stroke="#4472C4" stroke-width="2.5"/>
+  
+  <!-- Data points -->
+  <circle cx="38" cy="48" r="2.5" fill="#4472C4"/>
+  <circle cx="49" cy="35" r="2.5" fill="#4472C4"/>
+  <circle cx="60" cy="48" r="2.5" fill="#4472C4"/>
+  
+  <circle cx="38" cy="54" r="2.5" fill="#4472C4"/>
+  <circle cx="49" cy="41" r="2.5" fill="#4472C4"/>
+  <circle cx="60" cy="54" r="2.5" fill="#4472C4"/>
+  
+  <circle cx="38" cy="42" r="2.5" fill="#4472C4"/>
+  <circle cx="49" cy="29" r="2.5" fill="#4472C4"/>
+  <circle cx="60" cy="42" r="2.5" fill="#4472C4"/>
+  
+  <!-- Bar chart representation -->
+  <rect x="70" y="35" width="5" height="13" fill="#4472C4"/>
+  <rect x="76" y="40" width="5" height="8" fill="#4472C4"/>
+  <rect x="82" y="30" width="5" height="18" fill="#4472C4"/>
+  
+  <!-- Seaborn text -->
+  <text x="64" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#4472C4">seaborn</text>
+</svg>

--- a/icons/seaborn/seaborn-plain.svg
+++ b/icons/seaborn/seaborn-plain.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Seaborn Plain Logo - Single color version -->
+  <circle cx="64" cy="64" r="60" fill="none" stroke="#4472C4" stroke-width="3"/>
+  
+  <!-- Simplified wave patterns -->
+  <path d="M20 64 Q32 44, 44 64 T68 64" fill="none" stroke="#4472C4" stroke-width="4"/>
+  <path d="M20 74 Q32 54, 44 74 T68 74" fill="none" stroke="#4472C4" stroke-width="4"/>
+  <path d="M20 54 Q32 34, 44 54 T68 54" fill="none" stroke="#4472C4" stroke-width="4"/>
+  
+  <!-- Data points -->
+  <circle cx="28" cy="64" r="4" fill="#4472C4"/>
+  <circle cx="44" cy="44" r="4" fill="#4472C4"/>
+  <circle cx="60" cy="64" r="4" fill="#4472C4"/>
+  
+  <circle cx="28" cy="74" r="4" fill="#4472C4"/>
+  <circle cx="44" cy="54" r="4" fill="#4472C4"/>
+  <circle cx="60" cy="74" r="4" fill="#4472C4"/>
+  
+  <circle cx="28" cy="54" r="4" fill="#4472C4"/>
+  <circle cx="44" cy="34" r="4" fill="#4472C4"/>
+  <circle cx="60" cy="54" r="4" fill="#4472C4"/>
+  
+  <!-- Bar chart representation -->
+  <rect x="76" y="40" width="8" height="24" fill="#4472C4"/>
+  <rect x="86" y="50" width="8" height="14" fill="#4472C4"/>
+  <rect x="96" y="30" width="8" height="34" fill="#4472C4"/>
+</svg>


### PR DESCRIPTION
## New Icon: Seaborn

This PR adds a new icon for Seaborn, a Python data visualization library based on matplotlib.

### Details
- **Icon versions**: original, original-wordmark, plain, plain-wordmark, line
- **Color**: #4472C4 (Seaborn's brand blue)
- **Tags**: python, data-visualization, statistics, matplotlib, library, data-science, analytics
- **Altnames**: sns (common import alias)

### Related
- Icon request: (if there was an issue, reference it here)
- All SVGs follow Devicon standards
- JSON entry properly placed in alphabetical order
